### PR TITLE
Add MacOS-specific ui changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ obj/
 riderModule.iml
 /_ReSharper.Caches/
 .vs/
+UserConfig.toml
+build-mac.sh

--- a/.idea/.idea.MercuryMapper.dir/.idea/.gitignore
+++ b/.idea/.idea.MercuryMapper.dir/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/contentModel.xml
+/projectSettingsUpdater.xml
+/.idea.MercuryMapper.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.MercuryMapper.dir/.idea/encodings.xml
+++ b/.idea/.idea.MercuryMapper.dir/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.MercuryMapper.dir/.idea/indexLayout.xml
+++ b/.idea/.idea.MercuryMapper.dir/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.MercuryMapper.dir/.idea/vcs.xml
+++ b/.idea/.idea.MercuryMapper.dir/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/App.axaml
+++ b/App.axaml
@@ -13,6 +13,7 @@
             <Color x:Key='InputGestureBrush'>#808080</Color>
             <Color x:Key='ButtonBorderBrush'>#000000</Color>
             <Color x:Key='TitleBar'>#3C3F41</Color>
+            <Thickness x:Key="PlatformMargin">0</Thickness>
             <Color x:Key='TextBrush'>#DFDFDF</Color>
             <Color x:Key='TreeViewSelectedBrush'>#80315BB2</Color>
             

--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
@@ -19,6 +20,11 @@ public class App : Application
             desktop.MainWindow = new MainWindow();
 
         base.OnFrameworkInitializationCompleted();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            Application.Current.Resources["PlatformMargin"] = new Thickness(70, 0, 0, 0); // macOS margin
+        }
     }
 
     public static void SetCulture(string culture)

--- a/MercuryMapper.csproj
+++ b/MercuryMapper.csproj
@@ -6,7 +6,7 @@
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-        <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
+        <ApplicationIcon>Assets/AppIcon.ico</ApplicationIcon>
         <IsPackable>false</IsPackable>
         <Company>yasu3d</Company>
         <AssemblyVersion>1.0.0</AssemblyVersion>
@@ -32,78 +32,78 @@
     </ItemGroup>
 
     <ItemGroup>
-      <UpToDateCheckInput Remove="Views\MainViewControls\MainView_ButtonPanel.axaml" />
-      <UpToDateCheckInput Remove="Views\MainViewControls\MainView_OperationDrawer.axaml" />
-      <UpToDateCheckInput Remove="Views\MainViewControls\MainView_SongControls.axaml" />
+      <UpToDateCheckInput Remove="Views/MainViewControls/MainView_ButtonPanel.axaml" />
+      <UpToDateCheckInput Remove="Views/MainViewControls/MainView_OperationDrawer.axaml" />
+      <UpToDateCheckInput Remove="Views/MainViewControls/MainView_SongControls.axaml" />
     </ItemGroup>
 
     <ItemGroup>
-      <EmbeddedResource Update="Assets\Lang\Resources.resx">
+      <EmbeddedResource Update="Assets/Lang/Resources.resx">
         <Generator>PublicResXFileCodeGenerator</Generator>
         <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       </EmbeddedResource>
-      <EmbeddedResource Update="Assets\Lang\Resources.de-DE.resx">
+      <EmbeddedResource Update="Assets/Lang/Resources.de-DE.resx">
         <Generator>PublicResXFileCodeGenerator</Generator>
         <LastGenOutput>Resources.de-DE.Designer.cs</LastGenOutput>
       </EmbeddedResource>
     </ItemGroup>
 
     <ItemGroup>
-      <Compile Update="Assets\Locales\Resources.Designer.cs">
+      <Compile Update="Assets/Locales/Resources.Designer.cs">
         <DesignTime>True</DesignTime>
         <AutoGen>True</AutoGen>
         <DependentUpon>Resources.resx</DependentUpon>
       </Compile>
-      <Compile Update="Assets\Lang\Resources.Designer.cs">
+      <Compile Update="Assets/Lang/Resources.Designer.cs">
         <DesignTime>True</DesignTime>
         <AutoGen>True</AutoGen>
         <DependentUpon>Resources.resx</DependentUpon>
       </Compile>
-      <Compile Update="Assets\Lang\Resources.de-DE.Designer.cs">
+      <Compile Update="Assets/Lang/Resources.de-DE.Designer.cs">
         <DesignTime>True</DesignTime>
         <AutoGen>True</AutoGen>
         <DependentUpon>Resources.de-DE.resx</DependentUpon>
       </Compile>
-      <Compile Update="Views\Settings\SettingsView_Audio.axaml.cs">
+      <Compile Update="Views/Settings/SettingsView_Audio.axaml.cs">
         <DependentUpon>SettingsView_Audio.axaml</DependentUpon>
         <SubType>Code</SubType>
       </Compile>
-      <Compile Update="Views\Gimmicks\GimmickView_Stop.axaml.cs">
+      <Compile Update="Views/Gimmicks/GimmickView_Stop.axaml.cs">
         <DependentUpon>GimmickView_Stop.axaml</DependentUpon>
         <SubType>Code</SubType>
       </Compile>
-      <Compile Update="Views\SaturnFolderExportView.axaml.cs">
+      <Compile Update="Views/SaturnFolderExportView.axaml.cs">
         <DependentUpon>SaturnFolderExportView.axaml</DependentUpon>
         <SubType>Code</SubType>
       </Compile>
-      <Compile Update="Views\Online\OnlineView_CreateSession.axaml.cs">
+      <Compile Update="Views/Online/OnlineView_CreateSession.axaml.cs">
         <DependentUpon>OnlineView_CreateSession.axaml</DependentUpon>
         <SubType>Code</SubType>
       </Compile>
-      <Compile Update="Views\Misc\MiscView_AddComment.axaml.cs">
+      <Compile Update="Views/Misc/MiscView_AddComment.axaml.cs">
         <DependentUpon>AddCommentView.axaml</DependentUpon>
         <SubType>Code</SubType>
       </Compile>
     </ItemGroup>
 
     <ItemGroup>
-      <AvaloniaResource Include="Assets\EmptyJacket.png" />
-      <AvaloniaResource Include="Assets\AppIcon.png" />
-      <AvaloniaResource Include="Assets\AppIcon.ico" />
-      <AvaloniaResource Include="Assets\Inter.ttf" />
+      <AvaloniaResource Include="Assets/EmptyJacket.png" />
+      <AvaloniaResource Include="Assets/AppIcon.png" />
+      <AvaloniaResource Include="Assets/AppIcon.ico" />
+      <AvaloniaResource Include="Assets/Inter.ttf" />
     </ItemGroup>
 
     <!-- Windows x86 DLLs -->
     <ItemGroup>
-        <ContentWithTargetPath Include="lib\win-x86\bass.dll" Condition="'$(RuntimeIdentifier)' == 'win-x86'">
+        <ContentWithTargetPath Include="lib/win-x86/bass.dll" Condition="'$(RuntimeIdentifier)' == 'win-x86'">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <TargetPath>bass.dll</TargetPath>
         </ContentWithTargetPath>
-        <ContentWithTargetPath Include="lib\win-x86\bass_fx.dll" Condition="'$(RuntimeIdentifier)' == 'win-x86'">
+        <ContentWithTargetPath Include="lib/win-x86/bass_fx.dll" Condition="'$(RuntimeIdentifier)' == 'win-x86'">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <TargetPath>bass_fx.dll</TargetPath>
         </ContentWithTargetPath>
-        <ContentWithTargetPath Include="lib\win-x86\bassflac.dll" Condition="'$(RuntimeIdentifier)' == 'win-x86'">
+        <ContentWithTargetPath Include="lib/win-x86/bassflac.dll" Condition="'$(RuntimeIdentifier)' == 'win-x86'">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <TargetPath>bassflac.dll</TargetPath>
         </ContentWithTargetPath>
@@ -111,15 +111,15 @@
     
     <!-- Windows x64 DLLs -->
     <ItemGroup>
-      <ContentWithTargetPath Include="lib\win-x64\bass.dll" Condition="'$(RuntimeIdentifier)' == 'win-x64'">
+      <ContentWithTargetPath Include="lib/win-x64/bass.dll" Condition="'$(RuntimeIdentifier)' == 'win-x64'">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <TargetPath>bass.dll</TargetPath>
       </ContentWithTargetPath>
-      <ContentWithTargetPath Include="lib\win-x64\bass_fx.dll" Condition="'$(RuntimeIdentifier)' == 'win-x64'">
+      <ContentWithTargetPath Include="lib/win-x64/bass_fx.dll" Condition="'$(RuntimeIdentifier)' == 'win-x64'">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <TargetPath>bass_fx.dll</TargetPath>
       </ContentWithTargetPath>
-      <ContentWithTargetPath Include="lib\win-x64\bassflac.dll" Condition="'$(RuntimeIdentifier)' == 'win-x64'">
+      <ContentWithTargetPath Include="lib/win-x64/bassflac.dll" Condition="'$(RuntimeIdentifier)' == 'win-x64'">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <TargetPath>bassflac.dll</TargetPath>
       </ContentWithTargetPath>
@@ -127,15 +127,15 @@
 
     <!-- macOS Dynamic Libraries -->
     <ItemGroup>
-        <ContentWithTargetPath Include="lib\darwin\libbass.dylib" Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
+        <ContentWithTargetPath Include="lib/darwin/libbass.dylib" Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <TargetPath>libbass.dylib</TargetPath>
         </ContentWithTargetPath>
-        <ContentWithTargetPath Include="lib\darwin\libbass_fx.dylib" Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
+        <ContentWithTargetPath Include="lib/darwin/libbass_fx.dylib" Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <TargetPath>libbass_fx.dylib</TargetPath>
         </ContentWithTargetPath>
-        <ContentWithTargetPath Include="lib\darwin\libbassflac.dylib" Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
+        <ContentWithTargetPath Include="lib/darwin/libbassflac.dylib" Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <TargetPath>libbassflac.dylib</TargetPath>
         </ContentWithTargetPath>
@@ -143,15 +143,15 @@
 
     <!-- Linux Shared Objects -->
     <ItemGroup>
-        <ContentWithTargetPath Include="lib\linux-x64\libbass.so" Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+        <ContentWithTargetPath Include="lib/linux-x64/libbass.so" Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <TargetPath>libbass.so</TargetPath>
         </ContentWithTargetPath>
-        <ContentWithTargetPath Include="lib\linux-x64\libbass_fx.so" Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+        <ContentWithTargetPath Include="lib/linux-x64/libbass_fx.so" Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <TargetPath>libbass_fx.so</TargetPath>
         </ContentWithTargetPath>
-        <ContentWithTargetPath Include="lib\linux-x64\libbassflac.so" Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+        <ContentWithTargetPath Include="lib/linux-x64/libbassflac.so" Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <TargetPath>libbassflac.so</TargetPath>
         </ContentWithTargetPath>
@@ -159,20 +159,20 @@
 
     <!-- Linux ARM Shared Objects -->
     <ItemGroup>
-        <ContentWithTargetPath Include="lib\linux-arm64\libbass.so" Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
+        <ContentWithTargetPath Include="lib/linux-arm64/libbass.so" Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <TargetPath>libbass.so</TargetPath>
         </ContentWithTargetPath>
-        <ContentWithTargetPath Include="lib\linux-arm64\libbass_fx.so" Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
+        <ContentWithTargetPath Include="lib/linux-arm64/libbass_fx.so" Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <TargetPath>libbass_fx.so</TargetPath>
         </ContentWithTargetPath>
-        <ContentWithTargetPath Include="lib\linux-arm64\libbassflac.so" Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
+        <ContentWithTargetPath Include="lib/linux-arm64/libbassflac.so" Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <TargetPath>libbassflac.so</TargetPath>
         </ContentWithTargetPath>
     </ItemGroup>
     <ItemGroup>
-      <None Remove="Views\Online\OnlineView_CreateSession.axaml.cs~" />
+      <None Remove="Views/Online/OnlineView_CreateSession.axaml.cs~" />
     </ItemGroup>
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -1,11 +1,12 @@
 ﻿using Avalonia;
 using System;
 using Avalonia.Media;
+using Avalonia.Platform;
 
 namespace MercuryMapper.Config;
-
 class Program
 {
+    
     // Initialization code. Don't use any Avalonia, third-party APIs or any
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.

--- a/Views/MainView.axaml
+++ b/Views/MainView.axaml
@@ -9,11 +9,12 @@
              PropertyChanged="MainView_OnPropertyChanged"
              x:Class="MercuryMapper.Views.MainView">
     
-    <Grid ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,*,Auto">
+    <Grid ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,*,Auto" >
         
         <!-- Title Bar -->
-        <Grid ColumnDefinitions="Auto,*" RowDefinitions="*" Grid.Row="0" Grid.ColumnSpan="3" Grid.Column="0" Name="TitleBar">
-            <Menu Grid.Column="0" Background="{DynamicResource TitleBar}" Height="40">
+        <Grid ColumnDefinitions="Auto,*" RowDefinitions="*" Grid.Row="0" Grid.ColumnSpan="3" Grid.Column="0" Name="TitleBar" Background="{DynamicResource TitleBar}">
+            <!--Hotfix for Mac OS button ui overlap. TODO: Fix WIndow Drag Bug-->
+            <Menu Grid.Column="0" Height="40" Margin="{DynamicResource PlatformMargin}"> 
                 <MenuItem Width="40">
                     <MenuItem.Header>
                         <Image Source="/Assets/AppIcon.ico" Width="20"/>


### PR DESCRIPTION
Adds ui padding for only mac os as the default ui overlaps with mac's user interface.

I'd add the compiled mercury into releases as well but I don't have access. Feel free to change this as you'd like.
<img width="338" alt="image" src="https://github.com/user-attachments/assets/97d8f9c0-6463-438b-aa59-8f0b4018cf2a" />
