### PR TITLE
 Added PreScan flag to CreateStream to accommodate VBR files (.mp3, some .flac)

### DIFF
--- a/Audio/BassSoundEngine.cs
+++ b/Audio/BassSoundEngine.cs
@@ -25,11 +25,11 @@ public class BassSoundEngine
     public static BassSound? GetSound(string filepath, bool loop, bool startPaused)
     {
         // attempt loading flac first
-        int decodingChannel = BassFlac.CreateStream(filepath, 0, 0, BassFlags.Decode);
+        int decodingChannel = BassFlac.CreateStream(filepath, 0, 0, BassFlags.Decode | BassFlags.Prescan);
         
         // load normally if that failed
         if (decodingChannel == 0 && Bass.LastError == Errors.FileFormat)
-            decodingChannel = Bass.CreateStream(filepath, 0, 0, BassFlags.Decode);
+            decodingChannel = Bass.CreateStream(filepath, 0, 0, BassFlags.Decode | BassFlags.Prescan);
         
         // explode if that failed too
         if (decodingChannel == 0) throw new($"Couldn't load selected audio file: {Bass.LastError}");


### PR DESCRIPTION
From https://www.un4seen.com/forum/?topic=10911.0 

.mp3 and possibly some .flac files contain [variable bitrate](https://en.wikipedia.org/wiki/Variable_bitrate). VBR will causes playback to not be in sync if user starts playback at any time!=0s. Adding Prescan flag fixes issue. According to forum post, this would delay loading in the file, but cost is negligible in practice.

Tested .mp3s with VBR, tested .flac to see if it runs. Did not test .flac with VBR; didn't have any on hand.